### PR TITLE
qa: remove cache dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- Nothing.
+- Remove `laminas/laminas-cache` dependency to avoid circular dependencies.
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -1,50 +1,52 @@
 {
-    "name": "laminas/laminas-cache-storage-adapter-memory",
-    "description": "Laminas cache adapter for memory",
-    "keywords": [
-        "laminas",
-        "cache"
-    ],
-    "license": "BSD-3-Clause",
-    "require": {
-        "php": "^5.6 || ^7.0",
-        "laminas/laminas-cache": "^2.10@dev"
-    },
-    "provide": {
-        "laminas/laminas-cache-storage-implementation": "1.0"
-    },
-    "require-dev": {
-        "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
-        "laminas/laminas-coding-standard": "~1.0.0",
-        "squizlabs/php_codesniffer": "^2.7"
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "extra": {
-    },
-    "autoload": {
-        "psr-4": {
-            "Laminas\\Cache\\Storage\\Adapter\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "LaminasTest\\Cache\\Storage\\Adapter\\": "test/unit",
-            "LaminasTest\\Cache\\Psr\\": "test/integration/Psr"
-        }
-    },
-    "scripts": {
-        "cs-check": "phpcs",
-        "cs-fix": "phpcbf",
-        "test": "phpunit --colors=always",
-        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
-    },
-    "support": {
-        "issues": "https://github.com/laminas/laminas-cache-storage-adapter-memory/issues",
-        "forum": "https://discourse.laminas.dev/",
-        "source": "https://github.com/laminas/laminas-cache-storage-adapter-memory",
-        "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-memory/",
-        "rss": "https://github.com/laminas/laminas-cache-storage-adapter-memory/releases.atom"
+  "name": "laminas/laminas-cache-storage-adapter-memory",
+  "description": "Laminas cache adapter for memory",
+  "keywords": [
+    "laminas",
+    "cache"
+  ],
+  "license": "BSD-3-Clause",
+  "require": {
+    "php": "^5.6 || ^7.0"
+  },
+  "provide": {
+    "laminas/laminas-cache-storage-implementation": "1.0"
+  },
+  "require-dev": {
+    "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
+    "laminas/laminas-coding-standard": "~1.0.0",
+    "squizlabs/php_codesniffer": "^2.7",
+    "laminas/laminas-cache": "^2.10"
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "extra": {},
+  "autoload": {
+    "psr-4": {
+      "Laminas\\Cache\\Storage\\Adapter\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "LaminasTest\\Cache\\Storage\\Adapter\\": "test/unit",
+      "LaminasTest\\Cache\\Psr\\": "test/integration/Psr"
+    }
+  },
+  "scripts": {
+    "cs-check": "phpcs",
+    "cs-fix": "phpcbf",
+    "test": "phpunit --colors=always",
+    "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
+  },
+  "support": {
+    "issues": "https://github.com/laminas/laminas-cache-storage-adapter-memory/issues",
+    "forum": "https://discourse.laminas.dev/",
+    "source": "https://github.com/laminas/laminas-cache-storage-adapter-memory",
+    "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-memory/",
+    "rss": "https://github.com/laminas/laminas-cache-storage-adapter-memory/releases.atom"
+  },
+  "conflict": {
+    "laminas/laminas-cache": "<2.10"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,17 @@
   "require": {
     "php": "^5.6 || ^7.0"
   },
+  "conflict": {
+    "laminas/laminas-cache": "<2.10"
+  },
   "provide": {
     "laminas/laminas-cache-storage-implementation": "1.0"
   },
   "require-dev": {
+    "laminas/laminas-cache": "^2.10",
     "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
     "laminas/laminas-coding-standard": "~1.0.0",
-    "squizlabs/php_codesniffer": "^2.7",
-    "laminas/laminas-cache": "^2.10"
+    "squizlabs/php_codesniffer": "^2.7"
   },
   "config": {
     "sort-packages": true
@@ -45,8 +48,5 @@
     "source": "https://github.com/laminas/laminas-cache-storage-adapter-memory",
     "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-memory/",
     "rss": "https://github.com/laminas/laminas-cache-storage-adapter-memory/releases.atom"
-  },
-  "conflict": {
-    "laminas/laminas-cache": "<2.10"
   }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Removing `laminas/laminas-cache` dependency to avoid circular dependency conflicts.