### PR TITLE
Replace `memory_limit` with `max_items`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -61,12 +61,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache.git",
-                "reference": "81501d4e6ba3603432c6f77246fce8d22df65e49"
+                "reference": "512dc92dead683f7713e6e40162fe40e619dd2ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/81501d4e6ba3603432c6f77246fce8d22df65e49",
-                "reference": "81501d4e6ba3603432c6f77246fce8d22df65e49",
+                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/512dc92dead683f7713e6e40162fe40e619dd2ad",
+                "reference": "512dc92dead683f7713e6e40162fe40e619dd2ad",
                 "shasum": ""
             },
             "require": {
@@ -147,7 +147,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-06-15T19:37:53+00:00"
+            "time": "2024-06-15T21:40:37+00:00"
         },
         {
             "name": "laminas/laminas-eventmanager",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,16 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
   <file src="src/Memory.php">
-    <MixedAssignment>
-      <code><![CDATA[$casToken]]></code>
-    </MixedAssignment>
     <PossiblyUnusedReturnValue>
       <code><![CDATA[bool]]></code>
     </PossiblyUnusedReturnValue>
-  </file>
-  <file src="test/unit/MemoryTest.php">
-    <MissingReturnType>
-      <code><![CDATA[testThrowOutOfSpaceException]]></code>
-    </MissingReturnType>
   </file>
 </files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -20,6 +20,10 @@
             <file name="test/integration/Composer/LaminasComponentInstallerIntegrationTest.php"/>
         </ignoreFiles>
     </projectFiles>
+    <issueHandlers>
+        <!-- Mixed assignments are valid for cache values and thus there might be mixed assignments as well -->
+        <MixedAssignment errorLevel="suppress"/>
+    </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
         <pluginClass class="Lctrs\PsalmPsrContainerPlugin\Plugin"/>

--- a/src/Memory/CacheItem.php
+++ b/src/Memory/CacheItem.php
@@ -10,12 +10,14 @@ namespace Laminas\Cache\Storage\Adapter\Memory;
 final class CacheItem
 {
     /**
+     * @param non-empty-string $key
      * @param non-negative-int $created
      * @param non-negative-int $lastModified
      * @param non-negative-int $expires
      * @param string[] $tags
      */
     public function __construct(
+        public readonly string $key,
         public readonly mixed $value,
         public readonly int $created,
         public int $lastModified,

--- a/src/MemoryOptions.php
+++ b/src/MemoryOptions.php
@@ -5,104 +5,38 @@ declare(strict_types=1);
 namespace Laminas\Cache\Storage\Adapter;
 
 use Laminas\Cache\Exception;
-use Laminas\Stdlib\AbstractOptions;
-
-use function ini_get;
-use function is_numeric;
-use function preg_match;
-use function strtoupper;
 
 final class MemoryOptions extends AdapterOptions
 {
-    public const UNLIMITED_MEMORY = 0;
+    public const UNLIMITED_ITEMS = 0;
 
-    protected int $memoryLimit;
-    private bool $defaultMemoryLimit = true;
-
-    /**
-     * @param iterable<string,mixed>|AbstractOptions|null $options
-     */
-    public function __construct(iterable|AbstractOptions|null $options = null)
-    {
-        // By default use half of PHP's memory limit if possible
-        $memoryLimit = $this->normalizeMemoryLimit((string) ini_get('memory_limit'));
-        if ($memoryLimit >= 0) {
-            $this->memoryLimit = (int) ($memoryLimit / 2);
-        } else {
-            $this->memoryLimit = self::UNLIMITED_MEMORY;
-        }
-
-        parent::__construct($options);
-    }
+    /** @var non-negative-int */
+    protected int $maxItems = self::UNLIMITED_ITEMS;
 
     /**
-     * - A number less or equal 0 will disable the memory limit
-     * - When a number is used, the value is measured in bytes. Shorthand notation may also be used.
-     * - If the used memory of PHP exceeds this limit an OutOfSpaceException
-     *   will be thrown.
-     *
-     * @link http://php.net/manual/faq.using.php#faq.using.shorthandbytes
-     *
-     * @psalm-api
+     * @param non-negative-int $maxItems
      */
-    public function setMemoryLimit(string|int $memoryLimit): MemoryOptions
+    public function setMaxItems(int $maxItems): self
     {
-        $memoryLimit = $this->normalizeMemoryLimit($memoryLimit);
-
-        if ($this->defaultMemoryLimit === false && $this->memoryLimit !== $memoryLimit) {
-            $this->triggerOptionEvent('memory_limit', $memoryLimit);
+        /**
+         * @psalm-suppress DocblockTypeContradiction Just because we expect non-negative-int does not prevent users
+         *                                           from passing negative integers.
+         */
+        if ($maxItems < 0) {
+            throw new Exception\InvalidArgumentException(
+                'Provided `maxItems` option must be greater than or equal to 0',
+            );
         }
-        $this->defaultMemoryLimit = false;
-        $this->memoryLimit        = $memoryLimit;
 
+        $this->maxItems = $maxItems;
         return $this;
     }
 
     /**
-     * Get memory limit
-     *
-     * If the used memory of PHP exceeds this limit an OutOfSpaceException
-     * will be thrown.
+     * @return non-negative-int
      */
-    public function getMemoryLimit(): int
+    public function getMaxItems(): int
     {
-        return $this->memoryLimit;
-    }
-
-    /**
-     * Normalized a given value of memory limit into the number of bytes
-     *
-     * @throws Exception\InvalidArgumentException
-     */
-    protected function normalizeMemoryLimit(string|int $value): int
-    {
-        if (is_numeric($value)) {
-            return (int) $value;
-        }
-
-        if (! preg_match('/(\-?\d+)\s*(\w*)/', (string) ini_get('memory_limit'), $matches)) {
-            throw new Exception\InvalidArgumentException("Invalid  memory limit '{$value}'");
-        }
-
-        $value = (int) $matches[1];
-        if ($value <= 0) {
-            return 0;
-        }
-
-        switch (strtoupper($matches[2])) {
-            case 'G':
-                $value *= 1024;
-                // no break
-
-            case 'M':
-                $value *= 1024;
-                // no break
-
-            case 'K':
-                $value *= 1024;
-                // no break
-        }
-
-        return $value;
+        return $this->maxItems;
     }
 }

--- a/test/unit/MemoryOptionsTest.php
+++ b/test/unit/MemoryOptionsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Cache\Storage\Adapter;
+
+use Laminas\Cache\Storage\Adapter\AdapterOptions;
+use Laminas\Cache\Storage\Adapter\MemoryOptions;
+
+/**
+ * @template-extends AbstractAdapterOptionsTest<MemoryOptions>
+ */
+final class MemoryOptionsTest extends AbstractAdapterOptionsTest
+{
+    protected function createAdapterOptions(): AdapterOptions
+    {
+        return new MemoryOptions();
+    }
+
+    public function testSetMaxItems(): void
+    {
+        $options = new MemoryOptions();
+        $options->setMaxItems(1);
+        self::assertSame(1, $options->getMaxItems());
+    }
+}

--- a/test/unit/MemoryTest.php
+++ b/test/unit/MemoryTest.php
@@ -58,7 +58,7 @@ final class MemoryTest extends AbstractCommonAdapterTest
         self::assertSame(['foo'], $storage->setItems(['foo' => 'bar', 'bar' => 'baz', 'baz' => 'qoo', 'qoo' => 'ooq']));
     }
 
-    public function testWillOldestItemWhenPersistingMoreThanAllowedItems(): void
+    public function testWillRemoveOldestItemWhenPersistingMoreThanAllowedItems(): void
     {
         $storage = new Memory(new MemoryOptions(['max_items' => 3]));
         self::assertTrue($storage->setItem('foo', 'bar'));

--- a/test/unit/MemoryTest.php
+++ b/test/unit/MemoryTest.php
@@ -7,13 +7,11 @@ namespace LaminasTest\Cache\Storage\Adapter;
 use DateInterval;
 use DateTimeImmutable;
 use DateTimeZone;
-use Laminas\Cache\Exception\OutOfSpaceException;
 use Laminas\Cache\Storage\Adapter\Memory;
 use Laminas\Cache\Storage\Adapter\MemoryOptions;
 use Lcobucci\Clock\FrozenClock;
 
 use function assert;
-use function memory_get_usage;
 
 /**
  * @template-extends AbstractCommonAdapterTest<Memory, MemoryOptions>
@@ -27,14 +25,6 @@ final class MemoryTest extends AbstractCommonAdapterTest
         $this->storage = new Memory($this->options);
 
         parent::setUp();
-    }
-
-    public function testThrowOutOfSpaceException()
-    {
-        $this->options->setMemoryLimit(memory_get_usage(true) - 8);
-
-        $this->expectException(OutOfSpaceException::class);
-        $this->storage->addItem('test', 'test');
     }
 
     public function testMetadataIsCreatedAndModifiedAccordingly(): void
@@ -60,5 +50,34 @@ final class MemoryTest extends AbstractCommonAdapterTest
         self::assertNotNull($metadata);
         self::assertSame($now->getTimestamp(), $metadata->ctime);
         self::assertSame($future->getTimestamp(), $metadata->mtime);
+    }
+
+    public function testWillRemoveFirstItemWhenPersistingMoreThanAllowedItems(): void
+    {
+        $storage = new Memory(new MemoryOptions(['max_items' => 3]));
+        self::assertSame(['foo'], $storage->setItems(['foo' => 'bar', 'bar' => 'baz', 'baz' => 'qoo', 'qoo' => 'ooq']));
+    }
+
+    public function testWillOldestItemWhenPersistingMoreThanAllowedItems(): void
+    {
+        $storage = new Memory(new MemoryOptions(['max_items' => 3]));
+        self::assertTrue($storage->setItem('foo', 'bar'));
+        self::assertTrue($storage->setItem('bar', 'baz'));
+        self::assertTrue($storage->setItem('baz', 'qoo'));
+        self::assertTrue($storage->setItem('qoo', 'ooq'));
+        self::assertFalse($storage->hasItem('foo'));
+
+        $storage->flush();
+
+        $options = $storage->getOptions();
+        $options->setTtl(1000);
+        self::assertTrue($storage->setItem('foo', 'bar'));
+        self::assertTrue($storage->setItem('bar', 'baz'));
+        $options->setTtl(100);
+        self::assertTrue($storage->setItem('baz', 'qoo'));
+        $options->setTtl(1000);
+        self::assertTrue($storage->setItem('qoo', 'ooq'));
+
+        self::assertFalse($storage->hasItem('baz'));
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | yes
| New Feature   | yes
| RFC           | yes

### Description

<!--

Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding documentation?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE NEXT MINOR BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN
-->

The `memory_limit` implementation is flawed. It does not respect actual memory consumption by cache items but the amount of memory consumed by the application itself. Therefore, an alternative was needed. `symfony/cache` is using `max_items` as well and thus, this might be a good alternative for the `Memory` adapter as well.

When there are `max_items` configured, the `Memory` adapter now removes the oldest item(s) before creating new entries (in case the max items were exceeded).

This allows projects to limit the cache entries rather than the memory consumption of cache entries.

closes #57 
closes #56
closes #54 
